### PR TITLE
[SERV-478] Restrict access by IP

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,4 +31,5 @@ jobs:
             -Dlibcal.client2.id=${{ secrets.LIBCAL_CLIENT2_ID }}
             -Dlibcal.client2.secret=${{ secrets.LIBCAL_CLIENT2_SECRET }}
             -Dlibcal.token.endpoint="https://calendar.library.ucla.edu/1.1/oauth/token"
-            -Dlibcal.base.url="https://calendar.library.ucla.edu"
+            -Dlibcal.base.url="https://calendar.library.ucla.edu"\
+            -Dallowed.ips="1237.0.0.1"\

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ To build the project, which includes running a bunch of tests, type:
         -Dlibcal.base.url="https://calendar.library.ucla.edu" \
         -Dlibcal.auth.retry.count=3 \
         -Dlibcal.auth.retry.delay=10 \
-        -Dlibcal.auth.expires_in.padding=300
+        -Dlibcal.auth.expires_in.padding=300 \ 
+        -Dallowed.ips="127.0.0.1"
 
 ## Running in Development
 
@@ -43,6 +44,7 @@ You can also run the application directly on the host machine by defining enviro
     LIBCAL_AUTH_RETRY_COUNT=3 \
     LIBCAL_AUTH_RETRY_DELAY=10 \
     LIBCAL_AUTH_EXPIRES_IN_PADDING=300 \
+    ALLOWED_IPS="127.0.0.1" \
     mvn vertx:run
 
 ## Contact

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
     <libcal.auth.retry.count></libcal.auth.retry.count>
     <libcal.auth.retry.delay></libcal.auth.retry.delay>
     <libcal.auth.expires_in.padding></libcal.auth.expires_in.padding>
+    <allowed.ips></allowed.ips>
 
   </properties>
 
@@ -289,6 +290,7 @@
             <LIBCAL_AUTH_RETRY_COUNT>${libcal.auth.retry.count}</LIBCAL_AUTH_RETRY_COUNT>
             <LIBCAL_AUTH_RETRY_DELAY>${libcal.auth.retry.delay}</LIBCAL_AUTH_RETRY_DELAY>
             <LIBCAL_AUTH_EXPIRES_IN_PADDING>${libcal.auth.expires_in.padding}</LIBCAL_AUTH_EXPIRES_IN_PADDING>
+            <ALLOWED_IPS>${allowed.ips}</ALLOWED_IPS>
           </environmentVariables>
         </configuration>
       </plugin>
@@ -309,6 +311,7 @@
             <LIBCAL_AUTH_RETRY_COUNT>${libcal.auth.retry.count}</LIBCAL_AUTH_RETRY_COUNT>
             <LIBCAL_AUTH_RETRY_DELAY>${libcal.auth.retry.delay}</LIBCAL_AUTH_RETRY_DELAY>
             <LIBCAL_AUTH_EXPIRES_IN_PADDING>${libcal.auth.expires_in.padding}</LIBCAL_AUTH_EXPIRES_IN_PADDING>
+            <ALLOWED_IPS>${allowed.ips}</ALLOWED_IPS>
           </environmentVariables>
           <systemPropertyVariables>
             <vertx.logger-delegate-factory-class-name>io.vertx.core.logging.SLF4JLogDelegateFactory</vertx.logger-delegate-factory-class-name>
@@ -377,6 +380,7 @@
                   <LIBCAL_AUTH_RETRY_COUNT>${libcal.auth.retry.count}</LIBCAL_AUTH_RETRY_COUNT>
                   <LIBCAL_AUTH_RETRY_DELAY>${libcal.auth.retry.delay}</LIBCAL_AUTH_RETRY_DELAY>
                   <LIBCAL_AUTH_EXPIRES_IN_PADDING>${libcal.auth.expires_in.padding}</LIBCAL_AUTH_EXPIRES_IN_PADDING>
+                  <ALLOWED_IPS>${allowed.ips}</ALLOWED_IPS>
                 </env>
                 <!-- Test to make sure the server started as expected -->
                 <wait>

--- a/src/main/java/edu/ucla/library/libcal/Config.java
+++ b/src/main/java/edu/ucla/library/libcal/Config.java
@@ -66,6 +66,11 @@ public final class Config {
     public static final String LIBCAL_AUTH_EXPIRES_IN_PADDING = "LIBCAL_AUTH_EXPIRES_IN_PADDING";
 
     /**
+     * The set/range of IPs which can call the proxy service.
+     */
+    public static final String ALLOWED_IPS = "ALLOWED_IPS";
+
+    /**
      * Constant classes should have private constructors.
      */
     private Config() {

--- a/src/main/java/edu/ucla/library/libcal/Constants.java
+++ b/src/main/java/edu/ucla/library/libcal/Constants.java
@@ -38,6 +38,11 @@ public final class Constants {
     public static final String EOL_REGEX = "\\r|\\n|\\r\\n";
 
     /**
+     * The name of the HTTP request header used by the reverse proxy to carry the client IP address.
+     */
+    public static final String X_FORWARDED_FOR = "X-Forwarded-For";
+
+    /**
      * Constant classes should have private constructors.
      */
     private Constants() {

--- a/src/main/java/edu/ucla/library/libcal/handlers/ProxyHandler.java
+++ b/src/main/java/edu/ucla/library/libcal/handlers/ProxyHandler.java
@@ -2,6 +2,7 @@
 package edu.ucla.library.libcal.handlers;
 
 import static edu.ucla.library.libcal.MediaType.APPLICATION_JSON;
+import static info.freelibrary.util.Constants.COMMA;
 import static info.freelibrary.util.Constants.EMPTY;
 import static info.freelibrary.util.Constants.SLASH;
 
@@ -29,7 +30,6 @@ import java.util.Arrays;
 /**
  * A handler that processes status information requests.
  */
-@SuppressWarnings("PMD.AvoidCatchingGenericException")
 public class ProxyHandler implements Handler<RoutingContext> {
 
     /**
@@ -41,11 +41,6 @@ public class ProxyHandler implements Handler<RoutingContext> {
      * A constant for the "?" to lead an HTTP query string.
      */
     private static final String QUESTION_MARK = "?";
-
-    /**
-     * The name of the HTTP request header used by the reverse proxy to carry the client IP address.
-     */
-    private static final String X_FORWARDED_FOR = "X-Forwarded-For";
 
     /**
      * The handler's copy of the Vert.x instance.
@@ -71,6 +66,7 @@ public class ProxyHandler implements Handler<RoutingContext> {
      * Creates a handler that returns a status response.
      *
      * @param aVertx A Vert.x instance
+     * @param aConfig Application config stored in JSON
      */
     public ProxyHandler(final Vertx aVertx, final JsonObject aConfig) {
         myVertx = aVertx;
@@ -83,8 +79,8 @@ public class ProxyHandler implements Handler<RoutingContext> {
     public void handle(final RoutingContext aContext) {
         final HttpServerResponse response = aContext.response();
         final String path = aContext.request().path();
-        final String originalClientIP = aContext.request().headers().get("X_FORWARDED_FOR").split(",")[0];
-        final String[] allowedIPs = myConfig.getString(Config.ALLOWED_IPS).split(",");
+        final String originalClientIP = aContext.request().headers().get(Constants.X_FORWARDED_FOR).split(COMMA)[0];
+        final String[] allowedIPs = myConfig.getString(Config.ALLOWED_IPS).split(COMMA);
 
         if (Arrays.asList(allowedIPs).contains(originalClientIP)) {
             final String receivedQuery = path

--- a/src/main/java/edu/ucla/library/libcal/verticles/MainVerticle.java
+++ b/src/main/java/edu/ucla/library/libcal/verticles/MainVerticle.java
@@ -25,6 +25,7 @@ import io.vertx.core.eventbus.MessageConsumer;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.AllowForwardHeaders;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.openapi.RouterBuilder;
 import io.vertx.serviceproxy.ServiceBinder;
@@ -106,7 +107,8 @@ public class MainVerticle extends AbstractVerticle {
 
             // Empty-path router to handle the variable-format calls to ProxyHandler
             router = routeBuilder.createRouter();
-            router.route().handler(new ProxyHandler(getVertx()));
+            router.allowForward(AllowForwardHeaders.X_FORWARD);
+            router.route().handler(new ProxyHandler(getVertx(), aConfig));
 
             myServer = getVertx().createHttpServer(serverOptions).requestHandler(router);
 

--- a/src/main/resources/libcal-proxy_messages.xml
+++ b/src/main/resources/libcal-proxy_messages.xml
@@ -11,5 +11,6 @@
   <entry key="LCP_004">Authentication attempt failed: {}, retrying in {} seconds</entry>
   <entry key="LCP_005">Authentication failed: {}</entry>
   <entry key="LCP_006">Failure retrieving LibCal content: {}</entry>
+  <entry key="LCP_007">Request came from unauthorized IP: {}</entry>
 
 </properties>

--- a/src/test/java/edu/ucla/library/libcal/handlers/ProxyHandlerTest.java
+++ b/src/test/java/edu/ucla/library/libcal/handlers/ProxyHandlerTest.java
@@ -101,17 +101,16 @@ public class ProxyHandlerTest {
         final WebClient webClient = WebClient.create(aVertx);
         final int port = Integer.parseInt(DEFAULT_PORT);
 
-        webClient.get(port, Constants.LOCAL_HOST, badRequestPath)
-                .as(BodyCodec.string()).send(result -> {
-                    if (result.succeeded()) {
-                        final HttpResponse<String> response = result.result();
+        webClient.get(port, Constants.LOCAL_HOST, badRequestPath).as(BodyCodec.string()).send(result -> {
+            if (result.succeeded()) {
+                final HttpResponse<String> response = result.result();
 
-                        assertEquals(HTTP.NOT_FOUND, response.statusCode());
-                        assertTrue(response.body().contains("Not Found"));
-                        aContext.completeNow();
-                    } else {
-                        aContext.failNow(result.cause());
-                    }
-                });
+                assertEquals(HTTP.NOT_FOUND, response.statusCode());
+                assertTrue(response.body().contains("Not Found"));
+                aContext.completeNow();
+            } else {
+                aContext.failNow(result.cause());
+            }
+        });
     }
 }


### PR DESCRIPTION
Added logic to retrieve the client IP from the X-Forwarded-For header. 
During a Slack conversation with Parinita, she listed 5 servers, with 6 distinct IPs (documented in SERV-478), that will be used for testing. 
It seems likely that requests for the production release will be coming in from the main Library website, and from a cron job on a Library server (per another Slack convo with Parinita).
Therefore coded with assumption of small, comma-separated list of allowed IPs in application configuration.

Updates:
* Added logic to `ProxyHandler` to check client IP and return 403 for requests from IPs not in config
* Added X-Forwarded-For header to existing `ProxyHandler` tests
* Added new test to confirm 403 response to unauthorized IP
* Updated README and build script for new config variable