### PR TITLE
[SERV-493] Pass entire LibCal API response through our proxy service

### DIFF
--- a/src/main/java/edu/ucla/library/libcal/HttpResponseMapper.java
+++ b/src/main/java/edu/ucla/library/libcal/HttpResponseMapper.java
@@ -1,0 +1,130 @@
+
+package edu.ucla.library.libcal;
+
+import java.util.List;
+import java.util.Map;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpVersion;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.impl.HttpResponseImpl;
+
+/**
+ * A mapper that allows for sending and receiving {@link HttpResponse}s over the event bus.
+ */
+public class HttpResponseMapper {
+
+    /**
+     * The internal JSON key to associate with the HTTP protocol version of an HTTP response.
+     */
+    private static final String HTTP_VERSION = "http_version";
+
+    /**
+     * The internal JSON key to associate with the status code of an HTTP response.
+     */
+    private static final String STATUS_CODE = "status_code";
+
+    /**
+     * The internal JSON key to associate with the status message of an HTTP response.
+     */
+    private static final String STATUS_MESSAGE = "status_message";
+
+    /**
+     * The internal JSON key to associate with the headers of an HTTP response.
+     */
+    private static final String HEADERS = "headers";
+
+    /**
+     * The internal JSON key to associate with the trailers of an HTTP response.
+     */
+    private static final String TRAILERS = "trailers";
+
+    /**
+     * The internal JSON key to associate with the cookies of an HTTP response.
+     */
+    private static final String COOKIES = "cookies";
+
+    /**
+     * The internal JSON key to associate with the body of an HTTP response.
+     */
+    private static final String BODY = "body";
+
+    /**
+     * The internal JSON key to associate with the followed redirects of an HTTP response.
+     */
+    private static final String FOLLOWED_REDIRECTS = "followed_redirects";
+
+    /**
+     * Represents an {@HttpResponse} as a {@JsonObject}.
+     *
+     * @param aResponse The HTTP response
+     * @return The JsonObject representation
+     */
+    public JsonObject encode(final HttpResponse<String> aResponse) {
+        return new JsonObject() //
+                .put(HTTP_VERSION, aResponse.version()) //
+                .put(STATUS_CODE, aResponse.statusCode()) //
+                .put(STATUS_MESSAGE, aResponse.statusMessage()) //
+                .put(HEADERS, jsonArrayfromMultiMap(aResponse.headers())) //
+                .put(TRAILERS, jsonArrayfromMultiMap(aResponse.trailers())) //
+                .put(COOKIES, aResponse.cookies()) //
+                .put(BODY, aResponse.body()) //
+                .put(FOLLOWED_REDIRECTS, aResponse.followedRedirects());
+    }
+
+    /**
+     * Represents a {@link JsonObject} as an {@link HttpResponse}.
+     *
+     * @param aJsonObject The JSON object
+     * @return The HttpResponse representation
+     */
+    @SuppressWarnings("unchecked")
+    public HttpResponse<String> decode(final JsonObject aJsonObject) {
+        return new HttpResponseImpl<String>( //
+                HttpVersion.valueOf(aJsonObject.getString(HTTP_VERSION)), //
+                aJsonObject.getInteger(STATUS_CODE).intValue(), //
+                aJsonObject.getString(STATUS_MESSAGE), //
+                multiMapfromJsonArray(aJsonObject.getJsonArray(HEADERS)), //
+                multiMapfromJsonArray(aJsonObject.getJsonArray(TRAILERS)), //
+                (List<String>) aJsonObject.getJsonArray(COOKIES).getList(), //
+                aJsonObject.getString(BODY), //
+                (List<String>) aJsonObject.getJsonArray(FOLLOWED_REDIRECTS).getList());
+    }
+
+    /**
+     * Represents a {@link MultiMap} as a {@link JsonArray}.
+     *
+     * @param aMultiMap The map
+     * @return The JsonArray representation
+     */
+    private static JsonArray jsonArrayfromMultiMap(final MultiMap aMultiMap) {
+        final JsonArray array = new JsonArray();
+
+        aMultiMap.forEach((entryKey, entryValue) -> {
+            array.add(new JsonObject().put(entryKey, entryValue));
+        });
+
+        return array;
+    }
+
+    /**
+     * Represents a {@link JsonArray} as a {@link MultiMap}.
+     *
+     * @param aJsonArray The array
+     * @return The MultiMap representation
+     */
+    private static MultiMap multiMapfromJsonArray(final JsonArray aJsonArray) {
+        final MultiMap map = MultiMap.caseInsensitiveMultiMap();
+
+        aJsonArray.forEach(jsonObject -> {
+            final Map<String, Object> underlyingMap = ((JsonObject) jsonObject).getMap();
+            final Map.Entry<String, Object> entry = underlyingMap.entrySet().iterator().next();
+
+            map.add(entry.getKey(), (String) entry.getValue());
+        });
+
+        return map;
+    }
+}

--- a/src/main/java/edu/ucla/library/libcal/JsonKeys.java
+++ b/src/main/java/edu/ucla/library/libcal/JsonKeys.java
@@ -27,21 +27,6 @@ public final class JsonKeys {
     public static final String EXPIRES_IN = "expires_in";
 
     /**
-     * The status code returned with an HTTP response.
-     */
-    public static final String STATUS_CODE = "status_code";
-
-    /**
-     * The status message returned with an HTTP response.
-     */
-    public static final String STATUS_MESSAGE = "status_message";
-
-    /**
-     * The body of an HTTP response.
-     */
-    public static final String BODY = "body";
-
-    /**
      * Creates a new JSON keys constants class.
      */
     private JsonKeys() {

--- a/src/main/java/edu/ucla/library/libcal/handlers/ProxyHandler.java
+++ b/src/main/java/edu/ucla/library/libcal/handlers/ProxyHandler.java
@@ -4,7 +4,6 @@ package edu.ucla.library.libcal.handlers;
 import static edu.ucla.library.libcal.MediaType.APPLICATION_JSON;
 import static info.freelibrary.util.Constants.COMMA;
 import static info.freelibrary.util.Constants.EMPTY;
-import static info.freelibrary.util.Constants.SLASH;
 
 import com.github.veqryn.collect.Cidr4Trie;
 import com.github.veqryn.net.Cidr4;
@@ -94,7 +93,7 @@ public class ProxyHandler implements Handler<RoutingContext> {
             final String receivedQuery = path.concat(
                     aContext.request().query() != null ? QUESTION_MARK.concat(aContext.request().query()) : EMPTY);
             myTokenProxy.getBearerToken().compose(token -> {
-                return myApiProxy.getLibCalOutput(token, SLASH.concat(receivedQuery)).map(myMapper::decode);
+                return myApiProxy.getLibCalOutput(token, receivedQuery).map(myMapper::decode);
             }).onSuccess(libcalResponse -> {
                 final String body = libcalResponse.body();
 

--- a/src/main/java/edu/ucla/library/libcal/handlers/ProxyHandler.java
+++ b/src/main/java/edu/ucla/library/libcal/handlers/ProxyHandler.java
@@ -96,13 +96,19 @@ public class ProxyHandler implements Handler<RoutingContext> {
             myTokenProxy.getBearerToken().compose(token -> {
                 return myApiProxy.getLibCalOutput(token, SLASH.concat(receivedQuery)).map(myMapper::decode);
             }).onSuccess(libcalResponse -> {
+                final String body = libcalResponse.body();
+
                 response.setStatusCode(libcalResponse.statusCode());
                 response.setStatusMessage(libcalResponse.statusMessage());
 
                 libcalResponse.headers().forEach(response::putHeader);
                 libcalResponse.trailers().forEach(response::putTrailer);
 
-                response.end(libcalResponse.body());
+                if (body != null) {
+                    response.end(body);
+                } else {
+                    response.end();
+                }
             }).onFailure(failure -> {
                 returnError(response, HTTP.INTERNAL_SERVER_ERROR, failure.getMessage());
             });

--- a/src/main/java/edu/ucla/library/libcal/services/LibCalProxyService.java
+++ b/src/main/java/edu/ucla/library/libcal/services/LibCalProxyService.java
@@ -46,7 +46,7 @@ public interface LibCalProxyService {
      *
      * @param anOAuthToken An OAuth bearer token
      * @param aQuery The query string passes to the LibCal API
-     * @return A Future that resolves to the JSON response from LibCal
+     * @return A Future that resolves to the HTTP response from LibCal represented as a JsonObject
      */
     Future<JsonObject> getLibCalOutput(String anOAuthToken, String aQuery);
 

--- a/src/main/java/edu/ucla/library/libcal/services/LibCalProxyServiceImpl.java
+++ b/src/main/java/edu/ucla/library/libcal/services/LibCalProxyServiceImpl.java
@@ -2,7 +2,7 @@
 package edu.ucla.library.libcal.services;
 
 import edu.ucla.library.libcal.Config;
-import edu.ucla.library.libcal.JsonKeys;
+import edu.ucla.library.libcal.HttpResponseMapper;
 
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
@@ -27,6 +27,11 @@ public class LibCalProxyServiceImpl implements LibCalProxyService {
      */
     private final JsonObject myConfig;
 
+    /**
+     * The HTTP response serializer.
+     */
+    private final HttpResponseMapper myMapper = new HttpResponseMapper();
+
     LibCalProxyServiceImpl(final Vertx aVertx, final JsonObject aConfig) {
         myConfig = aConfig;
         myWebClient = WebClient.create(aVertx);
@@ -39,18 +44,13 @@ public class LibCalProxyServiceImpl implements LibCalProxyService {
          * output as string to avoid parsing errors
          */
         final Promise<JsonObject> promise = Promise.promise();
-        final HttpRequest<String> request;
-        final JsonObject response = new JsonObject();
         final String baseURL = myConfig.getString(Config.LIBCAL_BASE_URL);
+        final HttpRequest<String> request = myWebClient.getAbs(baseURL.concat(aQuery))
+                .bearerTokenAuthentication(anOAuthToken).as(BodyCodec.string()).ssl(true);
 
-        request = myWebClient.getAbs(baseURL.concat(aQuery)).bearerTokenAuthentication(anOAuthToken)
-                .as(BodyCodec.string()).ssl(true);
         request.send(asyncResult -> {
             if (asyncResult.succeeded()) {
-                response.put(JsonKeys.STATUS_CODE, asyncResult.result().statusCode());
-                response.put(JsonKeys.STATUS_MESSAGE, asyncResult.result().statusMessage());
-                response.put(JsonKeys.BODY, asyncResult.result().body());
-                promise.complete(response);
+                promise.complete(myMapper.encode(asyncResult.result()));
             } else {
                 promise.fail(asyncResult.cause());
             }

--- a/src/main/java/edu/ucla/library/libcal/services/LibCalProxyServiceImpl.java
+++ b/src/main/java/edu/ucla/library/libcal/services/LibCalProxyServiceImpl.java
@@ -5,7 +5,6 @@ import edu.ucla.library.libcal.Config;
 import edu.ucla.library.libcal.HttpResponseMapper;
 
 import io.vertx.core.Future;
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.HttpRequest;
@@ -23,9 +22,9 @@ public class LibCalProxyServiceImpl implements LibCalProxyService {
     private final WebClient myWebClient;
 
     /**
-     * App config in Json format.
+     * The LibCal base URL.
      */
-    private final JsonObject myConfig;
+    private final String myLibCalBaseURL;
 
     /**
      * The HTTP response serializer.
@@ -33,7 +32,7 @@ public class LibCalProxyServiceImpl implements LibCalProxyService {
     private final HttpResponseMapper myMapper = new HttpResponseMapper();
 
     LibCalProxyServiceImpl(final Vertx aVertx, final JsonObject aConfig) {
-        myConfig = aConfig;
+        myLibCalBaseURL = aConfig.getString(Config.LIBCAL_BASE_URL);
         myWebClient = WebClient.create(aVertx);
     }
 
@@ -43,20 +42,9 @@ public class LibCalProxyServiceImpl implements LibCalProxyService {
          * LibCal API returns JSON in variable formats (sometimes objects, sometimes arrays), so safer to handle API
          * output as string to avoid parsing errors
          */
-        final Promise<JsonObject> promise = Promise.promise();
-        final String baseURL = myConfig.getString(Config.LIBCAL_BASE_URL);
-        final HttpRequest<String> request = myWebClient.getAbs(baseURL.concat(aQuery))
+        final HttpRequest<String> request = myWebClient.getAbs(myLibCalBaseURL.concat(aQuery))
                 .bearerTokenAuthentication(anOAuthToken).as(BodyCodec.string()).ssl(true);
 
-        request.send(asyncResult -> {
-            if (asyncResult.succeeded()) {
-                promise.complete(myMapper.encode(asyncResult.result()));
-            } else {
-                promise.fail(asyncResult.cause());
-            }
-        });
-
-        return promise.future();
+        return request.send().map(myMapper::encode);
     }
-
 }

--- a/src/test/java/edu/ucla/library/libcal/HttpResponseMapperTest.java
+++ b/src/test/java/edu/ucla/library/libcal/HttpResponseMapperTest.java
@@ -1,0 +1,70 @@
+
+package edu.ucla.library.libcal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.vertx.core.Vertx;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.codec.BodyCodec;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+/**
+ * Tests {@link HttpResponseMapper}.
+ */
+@ExtendWith(VertxExtension.class)
+@TestInstance(Lifecycle.PER_CLASS)
+public class HttpResponseMapperTest {
+
+    /**
+     * An HTTP client.
+     */
+    private WebClient myWebClient;
+
+    /**
+     * A response mapper.
+     */
+    private HttpResponseMapper myMapper;
+
+    /**
+     * Sets up the test.
+     *
+     * @param aVertx A Vert.x instance
+     * @param aContext A test context
+     */
+    @BeforeAll
+    public void setUp(final Vertx aVertx, final VertxTestContext aContext) {
+        myWebClient = WebClient.create(aVertx);
+        myMapper = new HttpResponseMapper();
+
+        aContext.completeNow();
+    }
+
+    /**
+     * Tests that encode reverses decode.
+     *
+     * @param aVertx A Vert.x instance
+     * @param aContext A test context
+     */
+    @Test
+    public void testDecodeReversesEncode(final Vertx aVertx, final VertxTestContext aContext) {
+        myWebClient.getAbs("http://example.com").as(BodyCodec.string()).send().onSuccess(response -> {
+            aContext.verify(() -> {
+                final HttpResponse<String> decodedEncodedResponse = myMapper.decode(myMapper.encode(response));
+
+                assertEquals(response.statusCode(), decodedEncodedResponse.statusCode());
+                assertEquals(response.statusMessage(), decodedEncodedResponse.statusMessage());
+                assertEquals(response.headers().toString(), decodedEncodedResponse.headers().toString());
+                assertEquals(response.body(), decodedEncodedResponse.body());
+                assertEquals(response.trailers().toString(), decodedEncodedResponse.trailers().toString());
+            }).completeNow();
+        }).onFailure(aContext::failNow);
+    }
+}


### PR DESCRIPTION
These changes allow our proxy service to send back the entire LibCal API response. No more assumption that the Content-Type header is `application/json`, etc.