### PR TITLE
[SERV-498] Add POST Request Handling

### DIFF
--- a/src/main/java/edu/ucla/library/libcal/handlers/ProxyHandler.java
+++ b/src/main/java/edu/ucla/library/libcal/handlers/ProxyHandler.java
@@ -25,7 +25,6 @@ import info.freelibrary.util.LoggerFactory;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpHeaders;
-import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
@@ -49,11 +48,6 @@ public class ProxyHandler implements Handler<RoutingContext> {
      * A constant for the HTTP GET method name.
      */
     private static final String GET = "GET";
-
-    /**
-     * A constant for the HTTP POST methos name.
-     */
-    private static final String POST = "POST";
 
     /**
      * The handler's copy of the Vert.x instance.
@@ -105,7 +99,7 @@ public class ProxyHandler implements Handler<RoutingContext> {
             final String receivedQuery = path.concat(
                     aContext.request().query() != null ? QUESTION_MARK.concat(aContext.request().query()) : EMPTY);
             myTokenProxy.getBearerToken().compose(token -> {
-                if (method.equals(GET)) {
+                if (GET.equals(method)) {
                     return myApiProxy.getLibCalOutput(token, receivedQuery).map(myMapper::decode);
                 } else {
                     return myApiProxy.postLibCalOutput(token, receivedQuery, aContext.body().asJsonObject())

--- a/src/main/java/edu/ucla/library/libcal/handlers/ProxyHandler.java
+++ b/src/main/java/edu/ucla/library/libcal/handlers/ProxyHandler.java
@@ -96,8 +96,9 @@ public class ProxyHandler implements Handler<RoutingContext> {
             final String receivedQuery = path.concat(
                     aContext.request().query() != null ? QUESTION_MARK.concat(aContext.request().query()) : EMPTY);
             myTokenProxy.getBearerToken().compose(token -> {
-                return myApiProxy.getLibCalOutput(token, receivedQuery, method,
-                        payload != null ? payload.asJsonObject() : null).map(myMapper::decode);
+                return myApiProxy
+                        .getLibCalOutput(token, receivedQuery, method, payload != null ? payload.asString() : null)
+                        .map(myMapper::decode);
             }).onSuccess(libcalResponse -> {
                 final String body = libcalResponse.body();
 

--- a/src/main/java/edu/ucla/library/libcal/handlers/ProxyHandler.java
+++ b/src/main/java/edu/ucla/library/libcal/handlers/ProxyHandler.java
@@ -22,11 +22,9 @@ import edu.ucla.library.libcal.services.OAuthTokenService;
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;
 
-import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpHeaders;
-import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RequestBody;
@@ -46,16 +44,6 @@ public class ProxyHandler implements Handler<RoutingContext> {
      * A constant for the "?" to lead an HTTP query string.
      */
     private static final String QUESTION_MARK = "?";
-
-    /**
-     * A constant for the HTTP GET method name.
-     */
-    private static final String GET = "GET";
-
-    /**
-     * A constant for the HTTP GET method name.
-     */
-    private static final String POST = "POST";
 
     /**
      * The handler's copy of the Vert.x instance.
@@ -99,7 +87,7 @@ public class ProxyHandler implements Handler<RoutingContext> {
     public void handle(final RoutingContext aContext) {
         final HttpServerResponse response = aContext.response();
         final String path = aContext.request().path();
-        final HttpMethod method = aContext.request().method(); // .name();
+        final String method = aContext.request().method().name();
         final RequestBody payload = aContext.body();
         final String originalClientIP = aContext.request().remoteAddress().hostAddress();
         final Cidr4Trie<String> allowedIPs = buildAllowedNetwork(myConfig.getString(Config.ALLOWED_IPS).split(COMMA));
@@ -108,20 +96,8 @@ public class ProxyHandler implements Handler<RoutingContext> {
             final String receivedQuery = path.concat(
                     aContext.request().query() != null ? QUESTION_MARK.concat(aContext.request().query()) : EMPTY);
             myTokenProxy.getBearerToken().compose(token -> {
-		    try {
                 return myApiProxy.getLibCalOutput(token, receivedQuery, method,
-                        (payload != null ? payload.asJsonObject() : null)).map(myMapper::decode);
-		    } catch (Exception details) {
-		    	details.printStackTrace();
-			return Future.failedFuture(details);
-		    }
-                /*
-                 * if (GET.equals(method)) { return myApiProxy.getLibCalOutput(token,
-                 * receivedQuery).map(myMapper::decode); } else if (POST.equals(method)) { return
-                 * myApiProxy.postLibCalOutput(token, receivedQuery, aContext.body().asJsonObject())
-                 * .map(myMapper::decode); } else { returnError(response, HTTP.METHOD_NOT_ALLOWED,
-                 * LOGGER.getMessage(MessageCodes.LCP_008, method)); }
-                 */
+                        payload != null ? payload.asJsonObject() : null).map(myMapper::decode);
             }).onSuccess(libcalResponse -> {
                 final String body = libcalResponse.body();
 

--- a/src/main/java/edu/ucla/library/libcal/services/LibCalProxyService.java
+++ b/src/main/java/edu/ucla/library/libcal/services/LibCalProxyService.java
@@ -5,7 +5,6 @@ import io.vertx.codegen.annotations.ProxyGen;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
-import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
 import io.vertx.serviceproxy.ServiceProxyBuilder;
 
@@ -48,18 +47,9 @@ public interface LibCalProxyService {
      * @param anOAuthToken An OAuth bearer token
      * @param aQuery The query string passes to the LibCal API
      * @param aMethod The HTTP method used to contact LibCal
+     * @param aBody The (possibly empty) request payload from the client, represented as JSON
      * @return A Future that resolves to the HTTP response from LibCal represented as a JsonObject
      */
-    Future<JsonObject> getLibCalOutput(String anOAuthToken, String aQuery, HttpMethod aMethod, JsonObject aBody);
-
-    /**
-     * Retrieves the output of a POST LibCal API call.
-     *
-     * @param anOAuthToken An OAuth bearer token
-     * @param aQuery The query string passed to the LibCal API
-     * @param aBody The original request body, passed along to the LibCal API
-     * @return A Future that resolves to the JSON response from LibCal
-     */
-    Future<JsonObject> postLibCalOutput(String anOAuthToken, String aQuery, JsonObject aBody);
+    Future<JsonObject> getLibCalOutput(String anOAuthToken, String aQuery, String aMethod, JsonObject aBody);
 
 }

--- a/src/main/java/edu/ucla/library/libcal/services/LibCalProxyService.java
+++ b/src/main/java/edu/ucla/library/libcal/services/LibCalProxyService.java
@@ -42,12 +42,22 @@ public interface LibCalProxyService {
     }
 
     /**
-     * Retrieves the output of a LibCal API call.
+     * Retrieves the output of a GET LibCal API call.
      *
      * @param anOAuthToken An OAuth bearer token
      * @param aQuery The query string passes to the LibCal API
      * @return A Future that resolves to the HTTP response from LibCal represented as a JsonObject
      */
     Future<JsonObject> getLibCalOutput(String anOAuthToken, String aQuery);
+
+    /**
+     * Retrieves the output of a POST LibCal API call.
+     *
+     * @param anOAuthToken An OAuth bearer token
+     * @param aQuery The query string passed to the LibCal API
+     * @param aBody The original request body, passed along to the LibCal API
+     * @return A Future that resolves to the JSON response from LibCal
+     */
+    Future<JsonObject> postLibCalOutput(String anOAuthToken, String aQuery, JsonObject aBody);
 
 }

--- a/src/main/java/edu/ucla/library/libcal/services/LibCalProxyService.java
+++ b/src/main/java/edu/ucla/library/libcal/services/LibCalProxyService.java
@@ -5,6 +5,7 @@ import io.vertx.codegen.annotations.ProxyGen;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
 import io.vertx.serviceproxy.ServiceProxyBuilder;
 
@@ -46,9 +47,10 @@ public interface LibCalProxyService {
      *
      * @param anOAuthToken An OAuth bearer token
      * @param aQuery The query string passes to the LibCal API
+     * @param aMethod The HTTP method used to contact LibCal
      * @return A Future that resolves to the HTTP response from LibCal represented as a JsonObject
      */
-    Future<JsonObject> getLibCalOutput(String anOAuthToken, String aQuery);
+    Future<JsonObject> getLibCalOutput(String anOAuthToken, String aQuery, HttpMethod aMethod, JsonObject aBody);
 
     /**
      * Retrieves the output of a POST LibCal API call.

--- a/src/main/java/edu/ucla/library/libcal/services/LibCalProxyService.java
+++ b/src/main/java/edu/ucla/library/libcal/services/LibCalProxyService.java
@@ -13,6 +13,7 @@ import io.vertx.serviceproxy.ServiceProxyBuilder;
  */
 @ProxyGen
 @VertxGen
+@SuppressWarnings("PMD.UseObjectForClearerAPI")
 public interface LibCalProxyService {
 
     /**
@@ -42,14 +43,16 @@ public interface LibCalProxyService {
     }
 
     /**
-     * Retrieves the output of a GET LibCal API call.
+     * Retrieves the output of a LibCal API call.
+     * FYI: PMD wants a container rather than the multiple String paramss,
+     * but IMO the named params make the method call clearer
      *
      * @param anOAuthToken An OAuth bearer token
      * @param aQuery The query string passes to the LibCal API
      * @param aMethod The HTTP method used to contact LibCal
-     * @param aBody The (possibly empty) request payload from the client, represented as JSON
+     * @param aBody The (possibly empty) request payload from the client
      * @return A Future that resolves to the HTTP response from LibCal represented as a JsonObject
      */
-    Future<JsonObject> getLibCalOutput(String anOAuthToken, String aQuery, String aMethod, JsonObject aBody);
+    Future<JsonObject> getLibCalOutput(String anOAuthToken, String aQuery, String aMethod, String aBody);
 
 }

--- a/src/main/java/edu/ucla/library/libcal/services/LibCalProxyServiceImpl.java
+++ b/src/main/java/edu/ucla/library/libcal/services/LibCalProxyServiceImpl.java
@@ -49,7 +49,7 @@ public class LibCalProxyServiceImpl implements LibCalProxyService {
     }
 
     @Override
-    public Future<JsonObject> postLibCalOutput(String anOAuthToken, String aQuery, JsonObject aBody) {
+    public Future<JsonObject> postLibCalOutput(final String anOAuthToken, final String aQuery, final JsonObject aBody) {
         final HttpRequest<String> request = myWebClient.postAbs(myLibCalBaseURL.concat(aQuery))
                 .bearerTokenAuthentication(anOAuthToken).as(BodyCodec.string()).ssl(true);
 

--- a/src/main/java/edu/ucla/library/libcal/services/LibCalProxyServiceImpl.java
+++ b/src/main/java/edu/ucla/library/libcal/services/LibCalProxyServiceImpl.java
@@ -6,6 +6,7 @@ import edu.ucla.library.libcal.HttpResponseMapper;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.WebClient;
@@ -37,15 +38,17 @@ public class LibCalProxyServiceImpl implements LibCalProxyService {
     }
 
     @Override
-    public Future<JsonObject> getLibCalOutput(final String anOAuthToken, final String aQuery) {
+    public Future<JsonObject> getLibCalOutput(final String anOAuthToken, final String aQuery, final HttpMethod aMethod,
+            final JsonObject aBody) {
         /*
          * LibCal API returns JSON in variable formats (sometimes objects, sometimes arrays), so safer to handle API
          * output as string to avoid parsing errors
          */
-        final HttpRequest<String> request = myWebClient.getAbs(myLibCalBaseURL.concat(aQuery))
+        final HttpRequest<String> request = myWebClient.requestAbs(aMethod, myLibCalBaseURL.concat(aQuery))
                 .bearerTokenAuthentication(anOAuthToken).as(BodyCodec.string()).ssl(true);
 
-        return request.send().map(myMapper::encode);
+        return (aBody != null ? request.sendJsonObject(aBody).map(myMapper::encode)
+                : request.send().map(myMapper::encode));
     }
 
     @Override

--- a/src/main/java/edu/ucla/library/libcal/services/LibCalProxyServiceImpl.java
+++ b/src/main/java/edu/ucla/library/libcal/services/LibCalProxyServiceImpl.java
@@ -47,4 +47,12 @@ public class LibCalProxyServiceImpl implements LibCalProxyService {
 
         return request.send().map(myMapper::encode);
     }
+
+    @Override
+    public Future<JsonObject> postLibCalOutput(String anOAuthToken, String aQuery, JsonObject aBody) {
+        final HttpRequest<String> request = myWebClient.postAbs(myLibCalBaseURL.concat(aQuery))
+                .bearerTokenAuthentication(anOAuthToken).as(BodyCodec.string()).ssl(true);
+
+        return request.sendJsonObject(aBody).map(myMapper::encode);
+    }
 }

--- a/src/main/java/edu/ucla/library/libcal/services/LibCalProxyServiceImpl.java
+++ b/src/main/java/edu/ucla/library/libcal/services/LibCalProxyServiceImpl.java
@@ -6,6 +6,7 @@ import edu.ucla.library.libcal.HttpResponseMapper;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.HttpRequest;
@@ -15,6 +16,7 @@ import io.vertx.ext.web.codec.BodyCodec;
 /**
  * The implementation of LibCalProxyService.
  */
+@SuppressWarnings("PMD.UseObjectForClearerAPI")
 public class LibCalProxyServiceImpl implements LibCalProxyService {
 
     /**
@@ -39,7 +41,7 @@ public class LibCalProxyServiceImpl implements LibCalProxyService {
 
     @Override
     public Future<JsonObject> getLibCalOutput(final String anOAuthToken, final String aQuery, final String aMethod,
-            final JsonObject aBody) {
+            final String aBody) {
         /*
          * LibCal API returns JSON in variable formats (sometimes objects, sometimes arrays), so safer to handle API
          * output as string to avoid parsing errors
@@ -48,7 +50,7 @@ public class LibCalProxyServiceImpl implements LibCalProxyService {
                 myWebClient.requestAbs(HttpMethod.valueOf(aMethod), myLibCalBaseURL.concat(aQuery))
                         .bearerTokenAuthentication(anOAuthToken).as(BodyCodec.string()).ssl(true);
 
-        return aBody != null ? request.sendJsonObject(aBody).map(myMapper::encode)
+        return aBody != null ? request.sendBuffer(Buffer.buffer(aBody)).map(myMapper::encode)
                 : request.send().map(myMapper::encode);
     }
 

--- a/src/main/java/edu/ucla/library/libcal/services/LibCalProxyServiceImpl.java
+++ b/src/main/java/edu/ucla/library/libcal/services/LibCalProxyServiceImpl.java
@@ -38,24 +38,18 @@ public class LibCalProxyServiceImpl implements LibCalProxyService {
     }
 
     @Override
-    public Future<JsonObject> getLibCalOutput(final String anOAuthToken, final String aQuery, final HttpMethod aMethod,
+    public Future<JsonObject> getLibCalOutput(final String anOAuthToken, final String aQuery, final String aMethod,
             final JsonObject aBody) {
         /*
          * LibCal API returns JSON in variable formats (sometimes objects, sometimes arrays), so safer to handle API
          * output as string to avoid parsing errors
          */
-        final HttpRequest<String> request = myWebClient.requestAbs(aMethod, myLibCalBaseURL.concat(aQuery))
-                .bearerTokenAuthentication(anOAuthToken).as(BodyCodec.string()).ssl(true);
+        final HttpRequest<String> request =
+                myWebClient.requestAbs(HttpMethod.valueOf(aMethod), myLibCalBaseURL.concat(aQuery))
+                        .bearerTokenAuthentication(anOAuthToken).as(BodyCodec.string()).ssl(true);
 
-        return (aBody != null ? request.sendJsonObject(aBody).map(myMapper::encode)
-                : request.send().map(myMapper::encode));
+        return aBody != null ? request.sendJsonObject(aBody).map(myMapper::encode)
+                : request.send().map(myMapper::encode);
     }
 
-    @Override
-    public Future<JsonObject> postLibCalOutput(final String anOAuthToken, final String aQuery, final JsonObject aBody) {
-        final HttpRequest<String> request = myWebClient.postAbs(myLibCalBaseURL.concat(aQuery))
-                .bearerTokenAuthentication(anOAuthToken).as(BodyCodec.string()).ssl(true);
-
-        return request.sendJsonObject(aBody).map(myMapper::encode);
-    }
 }

--- a/src/main/java/edu/ucla/library/libcal/verticles/MainVerticle.java
+++ b/src/main/java/edu/ucla/library/libcal/verticles/MainVerticle.java
@@ -110,7 +110,7 @@ public class MainVerticle extends AbstractVerticle {
             // Empty-path router to handle the variable-format calls to ProxyHandler
             router = routeBuilder.createRouter();
             router.allowForward(AllowForwardHeaders.X_FORWARD);
-            // Add body handler so we can retirve incoming body from Apps client request
+            // Add body handler so we can retreve incoming body from Apps client request
             router.route().handler(postBodyHandler).handler(new ProxyHandler(getVertx(), aConfig));
 
             myServer = getVertx().createHttpServer(serverOptions).requestHandler(router);

--- a/src/main/resources/libcal-proxy_messages.xml
+++ b/src/main/resources/libcal-proxy_messages.xml
@@ -12,6 +12,5 @@
   <entry key="LCP_005">Authentication failed: {}</entry>
   <entry key="LCP_006">Failure retrieving LibCal content: {}</entry>
   <entry key="LCP_007">Request came from unauthorized IP: {}</entry>
-  <entry key="LCP_008">Request made with unsupported HTTP method: {}</entry>
 
 </properties>

--- a/src/main/resources/libcal-proxy_messages.xml
+++ b/src/main/resources/libcal-proxy_messages.xml
@@ -12,5 +12,6 @@
   <entry key="LCP_005">Authentication failed: {}</entry>
   <entry key="LCP_006">Failure retrieving LibCal content: {}</entry>
   <entry key="LCP_007">Request came from unauthorized IP: {}</entry>
+  <entry key="LCP_008">Request made with unsupported HTTP method: {}</entry>
 
 </properties>

--- a/src/test/java/edu/ucla/library/libcal/handlers/ProxyHandlerTest.java
+++ b/src/test/java/edu/ucla/library/libcal/handlers/ProxyHandlerTest.java
@@ -119,8 +119,8 @@ public class ProxyHandlerTest {
         final int port = Integer.parseInt(DEFAULT_PORT);
 
         webClient.post(port, Constants.LOCAL_HOST, postPath).putHeader(Constants.X_FORWARDED_FOR, GOOD_FORWARDS)
-                .putHeader(CONTENT_TYPE.toString(), APPLICATION_JSON.toString())
-                .expect(ResponsePredicate.SC_SUCCESS).as(BodyCodec.string()).sendJsonObject(payload, result -> {
+                .putHeader(CONTENT_TYPE.toString(), APPLICATION_JSON.toString()).expect(ResponsePredicate.SC_SUCCESS)
+                .as(BodyCodec.string()).sendJsonObject(payload, result -> {
                     if (result.succeeded()) {
                         final HttpResponse<String> response = result.result();
 
@@ -132,7 +132,6 @@ public class ProxyHandlerTest {
                     }
                 });
     }
-
 
     /**
      * Tests that a client handles bad input

--- a/src/test/java/edu/ucla/library/libcal/handlers/ProxyHandlerTest.java
+++ b/src/test/java/edu/ucla/library/libcal/handlers/ProxyHandlerTest.java
@@ -114,7 +114,7 @@ public class ProxyHandlerTest {
     public void testPostOutput(final Vertx aVertx, final VertxTestContext aContext) {
         final WebClient webClient = WebClient.create(aVertx);
         final String jsonSource = "src/test/resources/json/register.json";
-        final String postPath = "/api/1.1/events/9347519/register";
+        final String postPath = "/api/1.1/events/9353038/register";
         final JsonObject payload = new JsonObject(aVertx.fileSystem().readFileBlocking(jsonSource));
         final int port = Integer.parseInt(DEFAULT_PORT);
 

--- a/src/test/java/edu/ucla/library/libcal/handlers/ProxyHandlerTest.java
+++ b/src/test/java/edu/ucla/library/libcal/handlers/ProxyHandlerTest.java
@@ -63,6 +63,11 @@ public class ProxyHandlerTest {
     private static String REQUEST_PATH = "/api/1.1/hours/2572";
 
     /**
+     * A legit LibCal API call via POST
+     */
+    private static String POST_PATH = "/api/1.1/events/9353038/register";
+
+    /**
      * Sets up the test.
      *
      * @param aVertx A Vert.x instance
@@ -114,11 +119,10 @@ public class ProxyHandlerTest {
     public void testPostOutput(final Vertx aVertx, final VertxTestContext aContext) {
         final WebClient webClient = WebClient.create(aVertx);
         final String jsonSource = "src/test/resources/json/register.json";
-        final String postPath = "/api/1.1/events/9353038/register";
         final JsonObject payload = new JsonObject(aVertx.fileSystem().readFileBlocking(jsonSource));
         final int port = Integer.parseInt(DEFAULT_PORT);
 
-        webClient.post(port, Constants.LOCAL_HOST, postPath).putHeader(Constants.X_FORWARDED_FOR, GOOD_FORWARDS)
+        webClient.post(port, Constants.LOCAL_HOST, POST_PATH).putHeader(Constants.X_FORWARDED_FOR, GOOD_FORWARDS)
                 .putHeader(CONTENT_TYPE.toString(), APPLICATION_JSON.toString()).expect(ResponsePredicate.SC_SUCCESS)
                 .as(BodyCodec.string()).sendJsonObject(payload, result -> {
                     if (result.succeeded()) {
@@ -126,6 +130,34 @@ public class ProxyHandlerTest {
 
                         assertEquals(HTTP.OK, response.statusCode());
                         assertTrue(response.body().contains("booking_id"));
+                        aContext.completeNow();
+                    } else {
+                        aContext.failNow(result.cause());
+                    }
+                });
+    }
+
+    /**
+     * Tests that proxy handles bad POST request--this case, missing fields.
+     *
+     * @param aVertx A Vert.x instance
+     * @param aContext A test context
+     */
+    @Test
+    public void testBadPostOutput(final Vertx aVertx, final VertxTestContext aContext) {
+        final WebClient webClient = WebClient.create(aVertx);
+        final String jsonSource = "src/test/resources/json/bad_register.json";
+        final JsonObject payload = new JsonObject(aVertx.fileSystem().readFileBlocking(jsonSource));
+        final int port = Integer.parseInt(DEFAULT_PORT);
+
+        webClient.post(port, Constants.LOCAL_HOST, POST_PATH).putHeader(Constants.X_FORWARDED_FOR, GOOD_FORWARDS)
+                .putHeader(CONTENT_TYPE.toString(), APPLICATION_JSON.toString())
+                .expect(ResponsePredicate.SC_BAD_REQUEST).as(BodyCodec.string()).sendJsonObject(payload, result -> {
+                    if (result.succeeded()) {
+                        final HttpResponse<String> response = result.result();
+
+                        assertEquals(HTTP.BAD_REQUEST, response.statusCode());
+                        assertTrue(response.body().contains("incomplete required"));
                         aContext.completeNow();
                     } else {
                         aContext.failNow(result.cause());

--- a/src/test/java/edu/ucla/library/libcal/services/LibCalProxyServiceIT.java
+++ b/src/test/java/edu/ucla/library/libcal/services/LibCalProxyServiceIT.java
@@ -101,7 +101,7 @@ public class LibCalProxyServiceIT {
     @Test
     public final void testGetLibCalOutput(final Vertx aVertx, final VertxTestContext aContext) {
         myTokenProxy.getBearerToken().compose(token -> {
-            return myServiceProxy.getLibCalOutput(token, "/api/1.1/hours/2572");
+            return myServiceProxy.getLibCalOutput(token, "/api/1.1/hours/2572", "GET", null);
         }).onSuccess(output -> {
             assertTrue(output != null);
             aContext.completeNow();

--- a/src/test/resources/json/bad_register.json
+++ b/src/test/resources/json/bad_register.json
@@ -1,0 +1,7 @@
+{ 
+    "registration_type": "in-person", 
+    "form": { 
+        "first_name": "John", 
+        "last_name": "Smith"
+    } 
+}

--- a/src/test/resources/json/register.json
+++ b/src/test/resources/json/register.json
@@ -1,0 +1,9 @@
+{ 
+    "registration_type": "in-person", 
+    "form": { 
+        "first_name": "John", 
+        "last_name": "Smith", 
+        "email": "this@that.com", 
+        "q3": "Staff" 
+    } 
+}


### PR DESCRIPTION
Added logic to `ProxyHandler` and `LibCalProxyService` for receiving POST requests from Apps clients and passing request path/query/body along to LibCal. I'm assuming that Apps clients will construct complete and valid JSON payload, so not doing validation thereof.
TODO: The unit test calls LibCal event registration API. Events expire. We need to request that Apps makes a test event at least a year in the future, or else give Services team account permission to create test events as needed

Updates:
* Logic in `ProxyHandler` to distinguish GET and POST calls and pass to appropriate service method
* New method in `LibCalProxyService|Impl` to make a POST request to LibCal APIs
* Added `BodyHandler` to `ProxyHandler` router in `MainVerticle` to enable retrieving the client payload
* New unit test for POST request
* JSON file for the test request payload