### PR TITLE
Fix Javadoc syntax error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Build with Maven
         uses: samuelmeuli/action-maven-publish@201a45a3f311b2ee888f252ba9f4194257545709 # v1.4.0
         with:
-          maven_goals_phases: "clean verify"
+          maven_goals_phases: "clean compile javadoc:javadoc verify"
           maven_profiles: default
           maven_args: >
             -V -ntp -Ddocker.showLogs=true

--- a/src/main/java/edu/ucla/library/libcal/HttpResponseMapper.java
+++ b/src/main/java/edu/ucla/library/libcal/HttpResponseMapper.java
@@ -57,7 +57,7 @@ public class HttpResponseMapper {
     private static final String FOLLOWED_REDIRECTS = "followed_redirects";
 
     /**
-     * Represents an {@HttpResponse} as a {@JsonObject}.
+     * Represents an {@link HttpResponse} as a {@link JsonObject}.
      *
      * @param aResponse The HTTP response
      * @return The JsonObject representation


### PR DESCRIPTION
Also adds Javadoc generation goal to the Maven build step, so we can catch these kinds of errors earlier.