### PR TITLE
[SERV-503] Local Implementation of HttpResponse

### DIFF
--- a/src/main/java/edu/ucla/library/libcal/HttpResponseImpl.java
+++ b/src/main/java/edu/ucla/library/libcal/HttpResponseImpl.java
@@ -17,128 +17,128 @@ public class HttpResponseImpl<T> implements HttpResponse<T> {
     /**
      * Function variable to handle JsonArray decoding.
      */
-    public static final Function<Buffer, JsonArray> JSON_ARRAY_DECODER = buff -> {
-        final Object val = Json.decodeValue(buff);
-        if (val == null) {
+    public static final Function<Buffer, JsonArray> JSON_ARRAY_DECODER = buffer -> {
+        final Object value = Json.decodeValue(buffer);
+        if (value == null) {
             return null;
         }
-        if (val instanceof JsonArray) {
-            return (JsonArray) val;
+        if (value instanceof JsonArray) {
+            return (JsonArray) value;
         }
-        throw new DecodeException("Invalid Json Object decoded as " + val.getClass().getName());
+        throw new DecodeException("Invalid Json Object decoded as " + value.getClass().getName());
     };
 
     /**
-     * Function variable to handle JsonArray decoding.
+     * The HTTP protocol version of an HTTP response.
      */
     private final HttpVersion myVersion;
 
     /**
-     * Function variable to handle JsonArray decoding.
+     * The status code of an HTTP response.
      */
-    private final int statusCode;
+    private final int myStatusCode;
 
     /**
-     * Function variable to handle JsonArray decoding.
+     * The status message of an HTTP response.
      */
-    private final String statusMessage;
+    private final String myStatusMessage;
 
     /**
-     * Function variable to handle JsonArray decoding.
+     * The headers of an HTTP response.
      */
-    private final MultiMap headers;
+    private final MultiMap myHeaders;
 
     /**
-     * Function variable to handle JsonArray decoding.
+     * The trailers of an HTTP response.
      */
-    private final MultiMap trailers;
+    private final MultiMap myTrailers;
 
     /**
-     * Function variable to handle JsonArray decoding.
+     * The cookies of an HTTP response.
      */
-    private final List<String> cookies;
+    private final List<String> myCookies;
 
     /**
-     * Function variable to handle JsonArray decoding.
+     * The body of an HTTP response.
      */
-    private final T body;
+    private final T myBody;
 
     /**
-     * Function variable to handle JsonArray decoding.
+     * The followed redirects of an HTTP response.
      */
-    private final List<String> redirects;
+    private final List<String> myRedirects;
 
-    public HttpResponseImpl(HttpVersion aVersion, int statusCode, String statusMessage, MultiMap headers,
-            MultiMap trailers, List<String> cookies, T body, List<String> redirects) {
+    public HttpResponseImpl(final HttpVersion aVersion, final int aStatusCode, final String aStatusMessage, final MultiMap aHeaders,
+            final MultiMap aTrailers, final List<String> aCookies, final T aBody, final List<String> aRedirects) {
         myVersion = aVersion;
-        this.statusCode = statusCode;
-        this.statusMessage = statusMessage;
-        this.headers = headers;
-        this.trailers = trailers;
-        this.cookies = cookies;
-        this.body = body;
-        this.redirects = redirects;
+        myStatusCode = aStatusCode;
+        myStatusMessage = aStatusMessage;
+        myHeaders = aHeaders;
+        myTrailers = aTrailers;
+        myCookies = aCookies;
+        myBody = aBody;
+        myRedirects = aRedirects;
     }
 
     @Override
-    public HttpVersion myVersion() {
+    public HttpVersion version() {
         return myVersion;
     }
 
     @Override
     public int statusCode() {
-        return statusCode;
+        return myStatusCode;
     }
 
     @Override
     public String statusMessage() {
-        return statusMessage;
+        return myStatusMessage;
     }
 
     @Override
     public String getHeader(String headerName) {
-        return headers.get(headerName);
+        return myHeaders.get(headerName);
     }
 
     @Override
     public MultiMap trailers() {
-        return trailers;
+        return myTrailers;
     }
 
     @Override
     public String getTrailer(String trailerName) {
-        return trailers.get(trailerName);
+        return myTrailers.get(trailerName);
     }
 
     @Override
     public List<String> cookies() {
-        return cookies;
+        return myCookies;
     }
 
     @Override
     public MultiMap headers() {
-        return headers;
+        return myHeaders;
     }
 
     @Override
     public T body() {
-        return body;
+        return myBody;
     }
 
     @Override
     public Buffer bodyAsBuffer() {
-        return body instanceof Buffer ? (Buffer) body : null;
+        return myBody instanceof Buffer ? (Buffer) myBody : null;
     }
 
     @Override
     public List<String> followedRedirects() {
-        return redirects;
+        return myRedirects;
     }
 
     @Override
     public JsonArray bodyAsJsonArray() {
-        Buffer b = bodyAsBuffer();
-        return b != null ? JSON_ARRAY_DECODER.apply(b) : null;
+        final Buffer buffer = bodyAsBuffer();
+        return buffer != null ? JSON_ARRAY_DECODER.apply(buffer) : null;
     }
 
 }

--- a/src/main/java/edu/ucla/library/libcal/HttpResponseImpl.java
+++ b/src/main/java/edu/ucla/library/libcal/HttpResponseImpl.java
@@ -12,6 +12,9 @@ import io.vertx.ext.web.client.HttpResponse;
 import java.util.List;
 import java.util.function.Function;
 
+/**
+ * A class that implements the {@link HttpResponse} interface.
+ */
 public class HttpResponseImpl<T> implements HttpResponse<T> {
 
     /**
@@ -68,8 +71,21 @@ public class HttpResponseImpl<T> implements HttpResponse<T> {
      */
     private final List<String> myRedirects;
 
-    public HttpResponseImpl(final HttpVersion aVersion, final int aStatusCode, final String aStatusMessage, final MultiMap aHeaders,
-            final MultiMap aTrailers, final List<String> aCookies, final T aBody, final List<String> aRedirects) {
+    /**
+     * Creates an object that embodies an HTTP response.
+     *
+     * @param aVersion An HTTP protocol version
+     * @param aStatusCode An HTTP status code
+     * @param aStatusMessage An HTTP status message
+     * @param aHeaders A set of HTTP headers
+     * @param aTrailers A set of HTTP trailers
+     * @param aCookies A set of HTTP cookies
+     * @param aBody A body of an HTTP response
+     * @param aRedirects A set of followed redirects of an HTTP response
+     */
+    public HttpResponseImpl(final HttpVersion aVersion, final int aStatusCode, final String aStatusMessage,
+            final MultiMap aHeaders, final MultiMap aTrailers, final List<String> aCookies, final T aBody,
+            final List<String> aRedirects) {
         myVersion = aVersion;
         myStatusCode = aStatusCode;
         myStatusMessage = aStatusMessage;
@@ -96,8 +112,8 @@ public class HttpResponseImpl<T> implements HttpResponse<T> {
     }
 
     @Override
-    public String getHeader(String headerName) {
-        return myHeaders.get(headerName);
+    public String getHeader(final String aHeaderName) {
+        return myHeaders.get(aHeaderName);
     }
 
     @Override
@@ -106,8 +122,8 @@ public class HttpResponseImpl<T> implements HttpResponse<T> {
     }
 
     @Override
-    public String getTrailer(String trailerName) {
-        return myTrailers.get(trailerName);
+    public String getTrailer(final String aTrailerName) {
+        return myTrailers.get(aTrailerName);
     }
 
     @Override

--- a/src/main/java/edu/ucla/library/libcal/HttpResponseImpl.java
+++ b/src/main/java/edu/ucla/library/libcal/HttpResponseImpl.java
@@ -1,9 +1,14 @@
 
 package edu.ucla.library.libcal;
 
+import info.freelibrary.util.Logger;
+import info.freelibrary.util.LoggerFactory;
+
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpVersion;
+import io.vertx.core.json.DecodeException;
+import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.ext.web.client.HttpResponse;
 
@@ -13,6 +18,11 @@ import java.util.List;
  * A class that implements the {@link HttpResponse} interface.
  */
 public class HttpResponseImpl implements HttpResponse<String> {
+
+    /**
+     * The class's logger.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(HttpResponseImpl.class, MessageCodes.BUNDLE);
 
     /**
      * The HTTP protocol version of an HTTP response.
@@ -126,7 +136,7 @@ public class HttpResponseImpl implements HttpResponse<String> {
 
     @Override
     public Buffer bodyAsBuffer() {
-        throw new UnsupportedOperationException();
+        return Buffer.buffer(myBody);
     }
 
     @Override
@@ -136,7 +146,12 @@ public class HttpResponseImpl implements HttpResponse<String> {
 
     @Override
     public JsonArray bodyAsJsonArray() {
-        throw new UnsupportedOperationException();
+        final Object value = Json.decodeValue(myBody);
+        if (value instanceof JsonArray) {
+            return (JsonArray) value;
+        } else {
+            throw new DecodeException(LOGGER.getMessage(MessageCodes.LCP_008, value.getClass().getName()));
+        }
     }
 
 }

--- a/src/main/java/edu/ucla/library/libcal/HttpResponseImpl.java
+++ b/src/main/java/edu/ucla/library/libcal/HttpResponseImpl.java
@@ -4,32 +4,15 @@ package edu.ucla.library.libcal;
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpVersion;
-import io.vertx.core.json.DecodeException;
-import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.ext.web.client.HttpResponse;
 
 import java.util.List;
-import java.util.function.Function;
 
 /**
  * A class that implements the {@link HttpResponse} interface.
  */
-public class HttpResponseImpl<T> implements HttpResponse<T> {
-
-    /**
-     * Function variable to handle JsonArray decoding.
-     */
-    public static final Function<Buffer, JsonArray> JSON_ARRAY_DECODER = buffer -> {
-        final Object value = Json.decodeValue(buffer);
-        if (value == null) {
-            return null;
-        }
-        if (value instanceof JsonArray) {
-            return (JsonArray) value;
-        }
-        throw new DecodeException("Invalid Json Object decoded as " + value.getClass().getName());
-    };
+public class HttpResponseImpl implements HttpResponse<String> {
 
     /**
      * The HTTP protocol version of an HTTP response.
@@ -64,7 +47,7 @@ public class HttpResponseImpl<T> implements HttpResponse<T> {
     /**
      * The body of an HTTP response.
      */
-    private final T myBody;
+    private final String myBody;
 
     /**
      * The followed redirects of an HTTP response.
@@ -84,7 +67,7 @@ public class HttpResponseImpl<T> implements HttpResponse<T> {
      * @param aRedirects A set of followed redirects of an HTTP response
      */
     public HttpResponseImpl(final HttpVersion aVersion, final int aStatusCode, final String aStatusMessage,
-            final MultiMap aHeaders, final MultiMap aTrailers, final List<String> aCookies, final T aBody,
+            final MultiMap aHeaders, final MultiMap aTrailers, final List<String> aCookies, final String aBody,
             final List<String> aRedirects) {
         myVersion = aVersion;
         myStatusCode = aStatusCode;
@@ -137,13 +120,13 @@ public class HttpResponseImpl<T> implements HttpResponse<T> {
     }
 
     @Override
-    public T body() {
+    public String body() {
         return myBody;
     }
 
     @Override
     public Buffer bodyAsBuffer() {
-        return myBody instanceof Buffer ? (Buffer) myBody : null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -153,8 +136,7 @@ public class HttpResponseImpl<T> implements HttpResponse<T> {
 
     @Override
     public JsonArray bodyAsJsonArray() {
-        final Buffer buffer = bodyAsBuffer();
-        return buffer != null ? JSON_ARRAY_DECODER.apply(buffer) : null;
+        throw new UnsupportedOperationException();
     }
 
 }

--- a/src/main/java/edu/ucla/library/libcal/HttpResponseImpl.java
+++ b/src/main/java/edu/ucla/library/libcal/HttpResponseImpl.java
@@ -1,0 +1,144 @@
+
+package edu.ucla.library.libcal;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpVersion;
+import io.vertx.core.json.DecodeException;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
+import io.vertx.ext.web.client.HttpResponse;
+
+import java.util.List;
+import java.util.function.Function;
+
+public class HttpResponseImpl<T> implements HttpResponse<T> {
+
+    /**
+     * Function variable to handle JsonArray decoding.
+     */
+    public static final Function<Buffer, JsonArray> JSON_ARRAY_DECODER = buff -> {
+        final Object val = Json.decodeValue(buff);
+        if (val == null) {
+            return null;
+        }
+        if (val instanceof JsonArray) {
+            return (JsonArray) val;
+        }
+        throw new DecodeException("Invalid Json Object decoded as " + val.getClass().getName());
+    };
+
+    /**
+     * Function variable to handle JsonArray decoding.
+     */
+    private final HttpVersion myVersion;
+
+    /**
+     * Function variable to handle JsonArray decoding.
+     */
+    private final int statusCode;
+
+    /**
+     * Function variable to handle JsonArray decoding.
+     */
+    private final String statusMessage;
+
+    /**
+     * Function variable to handle JsonArray decoding.
+     */
+    private final MultiMap headers;
+
+    /**
+     * Function variable to handle JsonArray decoding.
+     */
+    private final MultiMap trailers;
+
+    /**
+     * Function variable to handle JsonArray decoding.
+     */
+    private final List<String> cookies;
+
+    /**
+     * Function variable to handle JsonArray decoding.
+     */
+    private final T body;
+
+    /**
+     * Function variable to handle JsonArray decoding.
+     */
+    private final List<String> redirects;
+
+    public HttpResponseImpl(HttpVersion aVersion, int statusCode, String statusMessage, MultiMap headers,
+            MultiMap trailers, List<String> cookies, T body, List<String> redirects) {
+        myVersion = aVersion;
+        this.statusCode = statusCode;
+        this.statusMessage = statusMessage;
+        this.headers = headers;
+        this.trailers = trailers;
+        this.cookies = cookies;
+        this.body = body;
+        this.redirects = redirects;
+    }
+
+    @Override
+    public HttpVersion myVersion() {
+        return myVersion;
+    }
+
+    @Override
+    public int statusCode() {
+        return statusCode;
+    }
+
+    @Override
+    public String statusMessage() {
+        return statusMessage;
+    }
+
+    @Override
+    public String getHeader(String headerName) {
+        return headers.get(headerName);
+    }
+
+    @Override
+    public MultiMap trailers() {
+        return trailers;
+    }
+
+    @Override
+    public String getTrailer(String trailerName) {
+        return trailers.get(trailerName);
+    }
+
+    @Override
+    public List<String> cookies() {
+        return cookies;
+    }
+
+    @Override
+    public MultiMap headers() {
+        return headers;
+    }
+
+    @Override
+    public T body() {
+        return body;
+    }
+
+    @Override
+    public Buffer bodyAsBuffer() {
+        return body instanceof Buffer ? (Buffer) body : null;
+    }
+
+    @Override
+    public List<String> followedRedirects() {
+        return redirects;
+    }
+
+    @Override
+    public JsonArray bodyAsJsonArray() {
+        Buffer b = bodyAsBuffer();
+        return b != null ? JSON_ARRAY_DECODER.apply(b) : null;
+    }
+
+}

--- a/src/main/java/edu/ucla/library/libcal/HttpResponseMapper.java
+++ b/src/main/java/edu/ucla/library/libcal/HttpResponseMapper.java
@@ -9,7 +9,6 @@ import io.vertx.core.http.HttpVersion;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.HttpResponse;
-import io.vertx.ext.web.client.impl.HttpResponseImpl;
 
 /**
  * A mapper that allows for sending and receiving {@link HttpResponse}s over the event bus.

--- a/src/main/java/edu/ucla/library/libcal/HttpResponseMapper.java
+++ b/src/main/java/edu/ucla/library/libcal/HttpResponseMapper.java
@@ -81,7 +81,7 @@ public class HttpResponseMapper {
      */
     @SuppressWarnings("unchecked")
     public HttpResponse<String> decode(final JsonObject aJsonObject) {
-        return new HttpResponseImpl<String>( //
+        return new HttpResponseImpl( //
                 HttpVersion.valueOf(aJsonObject.getString(HTTP_VERSION)), //
                 aJsonObject.getInteger(STATUS_CODE).intValue(), //
                 aJsonObject.getString(STATUS_MESSAGE), //

--- a/src/main/java/edu/ucla/library/libcal/services/LibCalProxyService.java
+++ b/src/main/java/edu/ucla/library/libcal/services/LibCalProxyService.java
@@ -43,7 +43,9 @@ public interface LibCalProxyService {
     }
 
     /**
-     * Retrieves the output of a LibCal API call. FYI: PMD wants a container rather than the multiple String paramss,
+     * Retrieves the output of a LibCal API call. 
+     *
+     * FYI: PMD wants a container rather than the multiple String paramss,
      * but IMO the named params make the method call clearer
      *
      * @param anOAuthToken An OAuth bearer token

--- a/src/main/java/edu/ucla/library/libcal/services/LibCalProxyService.java
+++ b/src/main/java/edu/ucla/library/libcal/services/LibCalProxyService.java
@@ -43,8 +43,7 @@ public interface LibCalProxyService {
     }
 
     /**
-     * Retrieves the output of a LibCal API call.
-     * FYI: PMD wants a container rather than the multiple String paramss,
+     * Retrieves the output of a LibCal API call. FYI: PMD wants a container rather than the multiple String paramss,
      * but IMO the named params make the method call clearer
      *
      * @param anOAuthToken An OAuth bearer token

--- a/src/main/java/edu/ucla/library/libcal/services/LibCalProxyService.java
+++ b/src/main/java/edu/ucla/library/libcal/services/LibCalProxyService.java
@@ -43,8 +43,10 @@ public interface LibCalProxyService {
     }
 
     /**
-     * Retrieves the output of a LibCal API call. FYI: PMD wants a container rather than the multiple String paramss,
-     * but IMO the named params make the method call clearer
+     * Retrieves the output of a LibCal API call.
+     *
+     * PMD wants a container rather than the multiple String params, but IMO
+     * the named params make the method call clearer
      *
      * @param anOAuthToken An OAuth bearer token
      * @param aQuery The query string passes to the LibCal API

--- a/src/main/java/edu/ucla/library/libcal/services/LibCalProxyService.java
+++ b/src/main/java/edu/ucla/library/libcal/services/LibCalProxyService.java
@@ -43,9 +43,7 @@ public interface LibCalProxyService {
     }
 
     /**
-     * Retrieves the output of a LibCal API call. 
-     *
-     * FYI: PMD wants a container rather than the multiple String paramss,
+     * Retrieves the output of a LibCal API call. FYI: PMD wants a container rather than the multiple String paramss,
      * but IMO the named params make the method call clearer
      *
      * @param anOAuthToken An OAuth bearer token

--- a/src/main/resources/libcal-proxy_messages.xml
+++ b/src/main/resources/libcal-proxy_messages.xml
@@ -12,5 +12,6 @@
   <entry key="LCP_005">Authentication failed: {}</entry>
   <entry key="LCP_006">Failure retrieving LibCal content: {}</entry>
   <entry key="LCP_007">Request came from unauthorized IP: {}</entry>
+  <entry key="LCP_008">Invalid Json Object decoded as: {}</entry>
 
 </properties>


### PR DESCRIPTION
Replaced non-API Vert.x `HttpResponseImpl` with local version.
* Copied non-API `HttpResponseImpl` to local class, applied Services naming and Javadoc conventions
* Spliced one function variable from `BodyCodecImpl` into local `HttpResponseImpl`, since `BodyCodecImpl` also appears to not be part of public API
* Updated `HttpResponseMapper` to use local `HttpResponseImpl`
* Small style tweak to `LibCalProxyService`