### PR TITLE
[SERV-601] Fix broken Docker CMD

### DIFF
--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -36,4 +36,4 @@ ENV JAR_PATH="/opt/${project.artifactId}/${project.artifactId}-${project.version
 ENV LOGGING_CONFIG="-Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.SLF4JLogDelegateFactory"
 ENV LOGBACK_CONFIG="-Dlogback.configurationFile=/etc/${project.artifactId}/logback.xml"
 
-CMD ["sh", "-c", "exec java \"${JAVA_OPTS}\" \"${LOGGING_CONFIG}\" \"${LOGBACK_CONFIG}\" -jar \"${JAR_PATH}\""]
+CMD ["sh", "-c", "exec java ${JAVA_OPTS} ${LOGGING_CONFIG} ${LOGBACK_CONFIG} -jar ${JAR_PATH}"]


### PR DESCRIPTION
The empty, but quoted, JAVA_OPTS in the Dockerfile's CMD breaks when the container is run outside of the Maven environment. Maven probably supplies this value so the problem only presents on deploying the container outside of Maven in an environment where JAVA_OPTS isn't set. Because I was able to confirm the logging working without any of the quotes in the CMD, I removed them all.