### PR TITLE
[SERV-709] Allow open access to LibCal event pages

### DIFF
--- a/src/main/java/edu/ucla/library/libcal/handlers/ProxyHandler.java
+++ b/src/main/java/edu/ucla/library/libcal/handlers/ProxyHandler.java
@@ -54,6 +54,9 @@ public class ProxyHandler implements Handler<RoutingContext> {
     /** The LibCal event form endpoint. */
     private static final Pattern EVENT_FORM = Pattern.compile("/api/1.1/events/form/[a-zA-Z0-9]+");
 
+    /** The LibCal event's HTML page. */
+    private static final Pattern EVENT_PAGE = Pattern.compile("/event/[a-zA-Z0-9]+");
+
     /**
      * The handler's copy of the Vert.x instance.
      */
@@ -105,6 +108,7 @@ public class ProxyHandler implements Handler<RoutingContext> {
         if (isOnNetwork(new Ip4(originalClientIP), allowedIPs) || isOpenEndpoint(path, method)) {
             final String receivedQuery = path.concat(
                     aContext.request().query() != null ? QUESTION_MARK.concat(aContext.request().query()) : EMPTY);
+
             myTokenProxy.getBearerToken().compose(token -> {
                 return myApiProxy
                         .getLibCalOutput(token, receivedQuery, method, payload != null ? payload.asString() : null)
@@ -197,7 +201,7 @@ public class ProxyHandler implements Handler<RoutingContext> {
         if (HttpMethod.POST.name().equals(aMethod)) {
             isAllowed = REGISTRATION.matcher(aPath).matches();
         } else if (HttpMethod.GET.name().equals(aMethod)) {
-            isAllowed = EVENT_FORM.matcher(aPath).matches();
+            isAllowed = EVENT_FORM.matcher(aPath).matches() || EVENT_PAGE.matcher(aPath).matches();
         }
 
         return isAllowed;

--- a/src/main/java/edu/ucla/library/libcal/services/LibCalProxyService.java
+++ b/src/main/java/edu/ucla/library/libcal/services/LibCalProxyService.java
@@ -13,7 +13,6 @@ import io.vertx.serviceproxy.ServiceProxyBuilder;
  */
 @ProxyGen
 @VertxGen
-@SuppressWarnings("PMD.UseObjectForClearerAPI")
 public interface LibCalProxyService {
 
     /**
@@ -28,7 +27,7 @@ public interface LibCalProxyService {
      * @param aConfig Application config in Json format
      * @return A Future that resolves to a service instance
      */
-    static Future<LibCalProxyService> create(Vertx aVertx, JsonObject aConfig) {
+    static Future<LibCalProxyService> create(final Vertx aVertx, final JsonObject aConfig) {
         return Future.succeededFuture(new LibCalProxyServiceImpl(aVertx, aConfig));
     }
 
@@ -38,13 +37,12 @@ public interface LibCalProxyService {
      * @param aVertx A Vert.x instance
      * @return A service proxy instance
      */
-    static LibCalProxyService createProxy(Vertx aVertx) {
+    static LibCalProxyService createProxy(final Vertx aVertx) {
         return new ServiceProxyBuilder(aVertx).setAddress(ADDRESS).build(LibCalProxyService.class);
     }
 
     /**
-     * Retrieves the output of a LibCal API call. PMD wants a container rather than the multiple String params, but IMO
-     * the named params make the method call clearer
+     * Retrieves the output of a LibCal API call.
      *
      * @param anOAuthToken An OAuth bearer token
      * @param aQuery The query string passes to the LibCal API
@@ -52,6 +50,7 @@ public interface LibCalProxyService {
      * @param aBody The (possibly empty) request payload from the client
      * @return A Future that resolves to the HTTP response from LibCal represented as a JsonObject
      */
+    @SuppressWarnings("PMD.UseObjectForClearerAPI") // PMD wants varargs, but the below is clearer
     Future<JsonObject> getLibCalOutput(String anOAuthToken, String aQuery, String aMethod, String aBody);
 
 }


### PR DESCRIPTION
The HTML page request really doesn't need the token, and I debated expanding the proxy a little to handle each type of request (static page and API) differently but, in the end, decided to minimize changes and just let the proxy do its thing -- the token use doesn't hurt anything, I don't think.

* Moved a PMD suppression closer to what was being overridden and tweaked its comment
* Added event pages to the types of requests that don't need an IP check
* Added some `final` modifiers to method parameters