### PR TITLE
[SERV-711] Update release-drafter version

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,7 +7,7 @@ jobs:
   draft-release-notes:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@ac463ffd9cc4c6ad5682af93dc3e3591c4657ee3 # v5.20.0
+      - uses: release-drafter/release-drafter@cfc5540ebc9d65a8731f02032e3d44db5e449fb6 # v5.22.0
         with:
           config-name: configs/release-drafter.yml
         env:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+#
+# This file contains a list of project codeowners
+#
+
+* @UCLALibrary/services-team-reviewers

--- a/pom.xml
+++ b/pom.xml
@@ -27,9 +27,9 @@
   </issueManagement>
 
   <properties>
-    <vertx.version>4.3.4</vertx.version>
+    <vertx.version>4.3.7</vertx.version>
     <freelib.utils.version>3.3.0</freelib.utils.version>
-    <freelib.maven.version>0.4.3</freelib.maven.version>
+    <freelib.maven.version>0.4.5</freelib.maven.version>
     <logback.version>1.4.4</logback.version>
 
     <!-- Build plugin versions -->
@@ -44,7 +44,7 @@
     <junit.version>5.8.0</junit.version>
 
     <!-- Docker component versions -->
-    <docker.alpine.version>3.16.2</docker.alpine.version>
+    <docker.alpine.version>3.17.0</docker.alpine.version>
     <jdk.version>17</jdk.version>
 
     <!-- Name of the main Vert.x verticle -->

--- a/src/test/java/edu/ucla/library/libcal/handlers/ProxyHandlerIT.java
+++ b/src/test/java/edu/ucla/library/libcal/handlers/ProxyHandlerIT.java
@@ -151,7 +151,7 @@ public class ProxyHandlerIT {
      */
     @Test
     public void testBadRequest(final Vertx aVertx, final VertxTestContext aContext) {
-        final HttpRequest<Buffer> request = myWebClient.get(myPort, INADDR_ANY, "/1.1/hours/2572"); // Bad path
+        final HttpRequest<Buffer> request = myWebClient.get(myPort, INADDR_ANY, "/0.1/hours/2572"); // Bad path
 
         request.putHeader(Constants.X_FORWARDED_FOR, GOOD_FORWARDS).send().onSuccess(response -> {
             final MultiMap headers = response.headers();


### PR DESCRIPTION
GA has deprecated `set-output` which our release action uses. This PR updates to the latest version of the release drafter so our builds don't break in the future.